### PR TITLE
Added gel plates to presenter factory

### DIFF
--- a/app/scripts/presenters/presenter_factory.js
+++ b/app/scripts/presenters/presenter_factory.js
@@ -61,8 +61,8 @@ define([
       case 'tube':        return this.presenters.createTubePresenter(owner);       break;
       case 'spin_column': return this.presenters.createSpinColumnPresenter(owner); break;
       case 'waste_tube':  return this.presenters.createWasteTubePresenter(owner);  break;
-      case 'tube_rack':        return this.presenters.createRackPresenter(owner);       break;
-      case 'gel':   return this.presenters.createGelPresenter(owner);       break;
+      case 'tube_rack':   return this.presenters.createRackPresenter(owner);       break;
+      case 'gel':         return this.presenters.createGelPresenter(owner);        break;
       default:            debugger;
     }
   };


### PR DESCRIPTION
When configuring the pipeline config for gels, the model should be defined as "gels" as this matches the presenter factory lookup and the API call.
