### PR TITLE
Updated connected model to allow multiple types of transfers. Transfer t...

### DIFF
--- a/app/scripts/models/connected.js
+++ b/app/scripts/models/connected.js
@@ -208,9 +208,9 @@ define([
           || transferDetails[0].output.resource.wells
           || transferDetails[0].output.resource.windows) {
             transfer = s2root.actions.transfer_plates_to_plates;
-        } else if (transferDetails[0].output.resource.tubes
-          || transferDetails[0].output.resource.wells
-          || transferDetails[0].output.resource.windows){
+        } else if (transferDetails[0].input.resource.tubes
+          || transferDetails[0].input.resource.wells
+          || transferDetails[0].input.resource.windows){
             transfer = s2root.actions.transfer_wells_to_tubes;
         } else {
             transfer =   s2root.actions.transfer_tubes_to_tubes;


### PR DESCRIPTION
...ype is determined as follows:

if output is a plate: plate -> plate
else input is a plate: plate -> tubes
else: tube -> tube

Tube -> plate  isn't possible so we can assume plate -> plate if the output type is a plate.

Plate is the term used in the mapper for plates racks and wells.
