### PR TITLE
2D tube scan bug fix

### DIFF
--- a/app/scripts/presenters/base_presenter.js
+++ b/app/scripts/presenters/base_presenter.js
@@ -17,11 +17,13 @@ define(['config'
     bindReturnKey: function (element, successCallback, errorCallback, validationCallback) {
       var thisPresenter = this;
 
-      // by default, we check that the input is 13 digits long.
       var validation = validationCallback || function (element, callback, errorCallback) {
         return function (event) {
           if (event.which !== 13) return;
-          if (BarcodeChecker.isBarcodeValid(event.currentTarget.value)) {
+
+          if (_.some(BarcodeChecker, function (validationCallback) {
+            return validationCallback(event.currentTarget.value);
+          })) {
             callback(event, element, thisPresenter);
           } else {
             errorCallback(event, element, thisPresenter);


### PR DESCRIPTION
Modified barcode validation in base_presenter, so that it will accept a barcode deemed valid  by any validation function in the barcode_checker library, so that 2D tubes can now be scanned
