### PR TITLE
fixed the large batch issue (row 6 and 7 were inverted)

### DIFF
--- a/app/scripts/html_partials/connected_partial.html
+++ b/app/scripts/html_partials/connected_partial.html
@@ -1,13 +1,4 @@
 <hr/>
-<div class="row0"></div>
-<div class="row1"></div>
-<div class="row2"></div>
-<div class="row3"></div>
-<div class="row4"></div>
-<div class="row5"></div>
-<div class="row7"></div>
-<div class="row6"></div>
-<div class="row8"></div>
-<div class="row9"></div>
-<div class="row10"></div>
-<div class="row11"></div>
+<% _.times (templateData.nbRow, function (index) { %>
+<div class="row<%= index %>"></div>
+<% }); %>

--- a/app/scripts/presenters/connected_presenter.js
+++ b/app/scripts/presenters/connected_presenter.js
@@ -37,7 +37,7 @@ define([
             PubSub.publish('s2.status.error', thisPresenter, error);
             thisPresenter.jquerySelection().trigger("s2.busybox.end_process");
           }).then(function(){
-            thisPresenter.jquerySelection().html(thisPresenter.template());
+            thisPresenter.jquerySelection().html(thisPresenter.template({nbRow:12}));
             thisPresenter.setupSubPresenters();
           });
       return this;


### PR DESCRIPTION
using _.template to generate the html, rather than a hardcoded list
(NOTE: the maximum nb of row is still hardcoded in connected presenter)
