### PR TITLE
Disable dynamically added components in linear process

### DIFF
--- a/app/scripts/app-components/linear-process/linear-process.js
+++ b/app/scripts/app-components/linear-process/linear-process.js
@@ -24,6 +24,7 @@ define([
     context.dynamic(function(component) {
       components.push(component);
       attachComponent(html, component);
+      html.trigger("s2.deactivate");
     });
 
     return {


### PR DESCRIPTION
They should be disabled until the process is, itself, enabled, which is
almost certainly after it has been built!
