### PR TITLE
While reading a manifest, UI halted because it couldn't find the correct template.

### DIFF
--- a/app/scripts/app-components/manifest/reader.js
+++ b/app/scripts/app-components/manifest/reader.js
@@ -1,12 +1,13 @@
 define([
     'text!app-components/manifest/_reader.html'
   , 'text!app-components/manifest/_row.html'
-  , 'lib/file_handling/manifests'
+  , 'lib/file_handling/manifests'  
   , 'app-components/dropzone/dropzone'
+  , 'lib/reception_templates'
 
   // Loaded in the global namespace after this comment
   , 'lib/jquery_extensions'
-], function (componentPartialHtml, sampleRowPartial, CSVParser, DropZone) {
+], function (componentPartialHtml, sampleRowPartial, CSVParser, DropZone, ReceptionTemplates) {
   'use strict';
 
   var viewTemplate = _.compose($, _.template(componentPartialHtml));
@@ -261,6 +262,9 @@ define([
     }
 
     var templateName       = dataAsArray[2][0]; // always A3 !!
+    if (!context.templates) {
+      context.templates = ReceptionTemplates;
+    }
     manifest.template = context.templates[templateName];
     if (_.isUndefined(manifest.template)) {
       manifest.errors.push("Could not find the corresponding template!");


### PR DESCRIPTION
Object 'context.templates' was empty and the reading of a manifest was failing. I suppose this was populated on another component, but it wasn't modified in development branch.
