### PR TITLE
Adds anchor with data url for allowing download of manifest

### DIFF
--- a/app/scripts/app-components/manifest/_maker.html
+++ b/app/scripts/app-components/manifest/_maker.html
@@ -29,7 +29,7 @@
           <input id="number-of-sample" type="text" value="1">
         </div>
         <button id="generateManifest" class="btn">Generate Manifest</button>
-        <button id="downloadManifest" class="btn">Download Manifest</button>
+        <a id="manifest-anchor"><span></span><button id="downloadManifest" class="btn">Download Manifest</button></a>
         <div id="printer-div"></div>
       </div>
     </form>

--- a/app/scripts/app-components/manifest/maker.js
+++ b/app/scripts/app-components/manifest/maker.js
@@ -223,8 +223,22 @@ define([
   }
 
   function downloadManifest(source, button) {
-    saveAs(source.data("manifest"), "manifest.xls");
-    button.prop("disabled", false);
+    if (navigator.userAgent.indexOf('Safari') != -1) {
+      var manifestAnchor = $("#manifest-anchor");
+      var reader = new FileReader();
+      reader.addEventListener("loadend", function() {
+        // Currently HTML5 Anchor download attribute is ignored by Safari browsers, so
+        // there is no way to make Safari force a filename if it is not performed with 
+        // right-button and "Save link as".
+        var dataURL=reader.result;
+        var anchor = manifestAnchor.attr("href", dataURL).attr("download", "manifest.xls");
+        manifestAnchor[0].click();
+      });
+      reader.readAsDataURL(source.data("manifest"));
+    } else {
+      saveAs(source.data("manifest"), "manifest.xls");
+    }
+    button.prop("disabled", false);    
   }
 
   function GenerateSamples(context, root, details) {


### PR DESCRIPTION
Adds anchor with data url for allowing download of manifest with 'right-button / Save as' interaction. Also performs auto-downloading of file for Safari. There is a problem inherent to Safari that disallows to specify a filename for the 
file downloaded. In this case anchor href can be renamed with "Right click / Save as".
