### PR TITLE
Fixes length of 2D barcode checker to 10 characters (2 characters for FR...

### DIFF
--- a/app/scripts/lib/barcode_checker.js
+++ b/app/scripts/lib/barcode_checker.js
@@ -16,7 +16,7 @@ define(['config'], function (config) {
           return (/^\d{12,13}$/.exec(barcode) !== null) && checkPrefix(barcode, barcodePrefixes);
         },
         is2DTubeBarcodeValid: function (barcode, barcodePrefixes) {
-          return /FR\d/.exec(barcode) !== null && checkPrefix(barcode, barcodePrefixes);
+          return /^FR\d{8}$/.exec(barcode) !== null && checkPrefix(barcode, barcodePrefixes);
         },
         isKitBarcodeValid: function (barcode, barcodePrefixes) {
           return /^\d{22}$/.exec(barcode) !== null && checkPrefix(barcode, barcodePrefixes);


### PR DESCRIPTION
... prefix and 8 for numbers in barcode)
