### PR TITLE
Resets batch into defaultModel when not found.

### DIFF
--- a/app/scripts/default/default_model.js
+++ b/app/scripts/default/default_model.js
@@ -40,8 +40,10 @@ define([
         return deferred.resolve(defaultModel);
       },
       function () {
+        // We reset the batch from the previous value it had on the model and
         // we resolve the promise because we already have a labware
-        // we simply didn't find a batch associated.
+        // we simply didn't find a batch associated.        
+        defaultModel.batch = null; 
         return deferred.resolve(defaultModel);
       });
 


### PR DESCRIPTION
It caused halt into login page model when a batch was over. See https://trello.com/c/OolGYbro
