### PR TITLE
Add fix for reracking when only one rack is used as source

### DIFF
--- a/app/scripts/app-components/re-racking/model.js
+++ b/app/scripts/app-components/re-racking/model.js
@@ -231,9 +231,11 @@ define([
 
       return $.when.apply(null, orderPromisesByRack)
       .then(function(){
-
+        // FIX:
+        var promises = (!_.isArray(arguments[0]))? [arguments] : arguments;
+        // END
         racksPerOrderUuid = _
-        .reduce(arguments, function(memo, rackOrders){
+        .reduce(promises, function(memo, rackOrders){
           var rack   = _.head(rackOrders);
           var orders = _.chain(rackOrders).rest().flatten().value();
 


### PR DESCRIPTION
Reracking was failing when the number of racks reracked was 1 (at least when I was testing it). This was applied yesterday to master and is in production. It should be in development too.
