### PR TITLE
Fix to the manifest reader

### DIFF
--- a/app/scripts/app-components/manifest/reader.js
+++ b/app/scripts/app-components/manifest/reader.js
@@ -227,7 +227,7 @@ define([
         memo[processName] = [];
       }
 
-      uuid = manifest.getSampleBySangerBarcode(sample["Tube Barcode"]).resource.uuid;
+      uuid = manifest.getSampleBySangerBarcode(sample).resource.uuid;
 
       memo[processName].push(uuid);
 

--- a/app/scripts/lib/manifest.js
+++ b/app/scripts/lib/manifest.js
@@ -111,7 +111,20 @@ define([
               .value();
     },
 
-    getSampleBySangerBarcode: function(sangerBarcode) {
+    _getBarcodeField: function() {
+      // Ugggghhhhhhhh
+      return _.chain(this.template.templates.display)
+        .filter(function(fields) {
+          return !_.isUndefined(fields.barcode);
+        })
+        .first()
+        .value()
+        .barcode
+        .columnName;
+    },
+
+    getSampleBySangerBarcode: function(sample) {
+      var sangerBarcode = sample[this._getBarcodeField()]
       return _.findWhere(this.details, { barcode: sangerBarcode });
     },
 


### PR DESCRIPTION
Manifest reader was trying to always read the barcode
from the application by sample['Tube Barcode']. This
obviously did not work for things that were no tubes
e.g. filter papers. The manifest object now looks at
the templates for the sample in order to determine its
type, so that it can extract the barcode
