### PR TITLE
Fixes Travis running the tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: node_js
 node_js:
-  - 0.8
+  - 0.10
 before_script: 
   - gem install compass
   - npm install -g grunt-cli
+  - bower install

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -129,8 +129,7 @@ module.exports = function (grunt) {
             all: {
                 options: {
                     run: false,
-                    urls: ['http://localhost:<%= connect.test.options.port %>/test/index.html'],
-                    reporter: 'Nyan'
+                    urls: ['http://localhost:<%= connect.test.options.port %>/test/index.html']
                 }
             }
         },

--- a/app/scripts/app-components/manifest/maker.js
+++ b/app/scripts/app-components/manifest/maker.js
@@ -3,11 +3,11 @@ define([
   "text!app-components/manifest/_custom_field.html",
   "app-components/labelling/printing",
   "lib/reception_templates",
+  "file_saver",
 
   // Global namespace updates
-  "lib/jquery_extensions",
-  "components/filesaver/filesaver"
-], function (componentPartialHtml, customFieldPartial, LabelPrinter, ReceptionTemplates) {
+  "lib/jquery_extensions"
+], function (componentPartialHtml, customFieldPartial, LabelPrinter, ReceptionTemplates, saveAs) {
   'use strict';
 
   var viewTemplate        = _.compose($, _.template(componentPartialHtml)),

--- a/app/scripts/main.js
+++ b/app/scripts/main.js
@@ -1,6 +1,8 @@
 require.config({
   shim:{
-
+    file_saver: {
+      exports: "saveAs"
+    }
   },
 
   baseUrl: "scripts",
@@ -22,7 +24,8 @@ require.config({
     event_emitter:      "../components/eventEmitter/EventEmitter",
     config:               "config",
     reception_templates:  "lib/reception_templates",
-    images:               "../images"
+    images:               "../images",
+    file_saver:           "../components/FileSaver/FileSaver"
   }
 });
 

--- a/bower.json
+++ b/bower.json
@@ -6,7 +6,7 @@
     "jquery-cookie": "https://github.com/carhartl/jquery-cookie.git",
     "requirejs": "~2.1.4",
     "requirejs-domready": "~2.0.1",
-    "S2Mapper": "https://github.com/sanger/S2Mapper.git#development",
+    "S2Mapper": "https://github.com/sanger/S2Mapper.git",
     "requirejs-text": "~2.0.5",
     "spin.js": "~1.3.0",
     "FileSaver": "https://github.com/eligrey/FileSaver.js.git",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "grunt-contrib-watch": "~0.4.0",
     "grunt-rev": "~0.1.0",
     "grunt-usemin": "~0.1.10",
-    "grunt-mocha": "~0.3.0",
+    "grunt-mocha": "~0.4.0",
     "grunt-open": "~0.2.0",
     "grunt-svgmin": "~0.1.0",
     "grunt-concurrent": "~0.1.0",
@@ -35,9 +35,9 @@
     "jayschema": "latest"
   },
   "engines": {
-    "node": ">=0.8.0"
+    "node": ">=0.10.0"
   },
   "scripts": {
-    "test": "grunt testAll --force"
+    "test": "grunt test"
   }
 }

--- a/test/index.html
+++ b/test/index.html
@@ -9,12 +9,14 @@
     <div id="mocha"></div>
     <script src="lib/mocha/mocha.js"></script>
     <script>
+        
         mocha.setup({
             ui: 'bdd',
             ignoreLeaks: false,
             bail: false,
             globals: ['WUIE_delays']
         });
+            
     </script>
     
     <!-- assertion framework -->

--- a/test/test_main.js
+++ b/test/test_main.js
@@ -1,6 +1,9 @@
 /* global requirejs, mocha */
 requirejs.config({
-  shim:{
+  shim: {
+    file_saver: {
+      exports: "saveAs"
+    }
   },
 
   baseUrl:"../app/scripts",
@@ -27,7 +30,9 @@ requirejs.config({
     underscore:           "../components/underscore/underscore-min",
     underscore_string:    "../components/underscore.string/lib/underscore.string",
     bootstrap:            "../components/sass-bootstrap/js",
-    components:           "../components"
+    components:           "../components",
+    event_emitter:        "../components/eventEmitter/EventEmitter",
+    file_saver:           "../components/FileSaver/FileSaver"
   }
 });
 


### PR DESCRIPTION
(This does not fix our tests, but gets Travis to actually run them now)

There were a number of reasons Travis could not
run our tests.
- npm install had SSL issues -
  Updated node version for travis
- PhantomJS was 404-ing dependencies -
  Added bower install to travis before_script
- RequireJS was throwing an error -
  Tracked down FileSaver as the guilty file. Was trying
  to be required as an AMD compatible module, even though
  it just adds a global variable. Used a shim to convert
  FileSaver into a proper RequireJS module

I also did these things...
- Modified bower.json -

Changed S2 Mapper so bower install would not complain
about it not being semver
- Reverted Mocha's reporter to default -
  Travis could not handle the Nyan cat
- Removed --force from npm test -
  Tests were exiting with error code 0 even though
  there were lots of errors.
