### PR TITLE
This task should be inside manifest_merge_service. This temporal fix sho...

### DIFF
--- a/app/scripts/app-components/manifest/reader.js
+++ b/app/scripts/app-components/manifest/reader.js
@@ -347,10 +347,21 @@ define([
   }
 
   function updateManifestDetails(root, manifest, resource) {
+    var padLeft13 = _.partial(function(padding, length, input) {
+      var result = input;
+      
+      var padLength = length - input.length;
+      for (var i = 0; i < padLength; i++) {
+        result = padding + result;
+      }
+      
+      return result;
+    }, "0", 13);
+        
     var details =
       _.chain(manifest.details)
         .filter(function(details) {
-          return details.label.value === resource.labels[details.label.column].value;
+          return padLeft13(details.label.value) === padLeft13(resource.labels[details.label.column].value);
         })
         .map(function(details) { details.resource = resource; return details; })
         .value();
@@ -370,6 +381,8 @@ define([
       );
     }
   }
+  
+  
 
   function sampleFromContainer(aliquots) {
     if (_.isEmpty(aliquots) || _.isUndefined(aliquots[0].sample)) {

--- a/app/scripts/lib/reception_templates/readers.js
+++ b/app/scripts/lib/reception_templates/readers.js
@@ -56,7 +56,30 @@ define([], function() {
   }
 
   function searchUsingEAN13(model, barcodes) {
-    return model.searchByBarcode().ean13(barcodes);
+    /**
+     * TODO: This task should be inside manifest_merge_service. This temporal fix should be removed and
+     * applied there.
+     * 
+     * The manifest.xls content is not congruent with the bulk_create_barcode response. If the barcode
+     * generated is less than 13 characters, bulk_create_barcode returns a padded barcode with zeros 
+     * at the beginning but the manifest don't have this padding in its barcodes. Because of this, 
+     * our subsequent label searching will fail because they are different to the database padded 
+     * content. In the app we will see the message: "Cannot find these details in the system".
+     * This is a problem in the content inside the manifest.xls, as every barcode inside it must be 
+     * strictly equal to the response of bulk_create_barcode. 
+     **/    
+    return model.searchByBarcode().ean13(_.map(barcodes, _.partial(padLeft, "0", 13)));
   }
 
+  function padLeft(padding, length, input) {
+    var result = input;
+    
+    var padLength = length - input.length;
+    for (var i = 0; i < padLength; i++) {
+      result = padding + result;
+    }
+    
+    return result;
+  }
+    
 });


### PR DESCRIPTION
...uld be

 removed and applied there.
The manifest.xls content is not congruent with the bulk_create_barcode response.
If the barcode generated is less than 13 characters, bulk_create_barcode
returns a padded barcode with zeros at the beginning but the manifest don't
have this padding in its barcodes. Because of this, our subsequent label
searching will fail because they are different to the database padded content.
In the app we will see the message: "Cannot find these details in the system".
This is a problem in the content inside the manifest.xls, as every barcode inside it must be strictly equal to the response of bulk_create_barcode.
