### PR TITLE
Revert "Not batched for fluidx tubes. Start transfers problem"

### DIFF
--- a/app/config/pipelines/qiacube_dna_and_rna_extraction.json
+++ b/app/config/pipelines/qiacube_dna_and_rna_extraction.json
@@ -275,7 +275,7 @@
             "model":       "tubes",
             "title":       "2D Extracted RNA Tube",
             "validation":  "2D_tube",
-            "not_batched": false
+            "not_batched": true
           }
         ]
       }
@@ -318,7 +318,7 @@
             "model":      "tubes",
             "title":      "2D Extracted DNA Tube",
             "validation": "2D_tube",
-            "not_batched": false
+            "not_batched": true
           }
         ]
       }

--- a/app/scripts/models/connected.js
+++ b/app/scripts/models/connected.js
@@ -62,7 +62,6 @@ define([
             deferred.reject({message: "Couldn't load the batch resource"});
           })
           .then(function () {
-            //return setupOutputs(thisModel);
             // FIXME: 
             // When the outputs are not in a batch (because maybe they need to be solved
             // individually in next steps) we have the problem that we don't know to which inputs


### PR DESCRIPTION
Reverts sanger/s2_extraction_pipeline#495

Fluidx tubes shouldnt be in a batch. This creates the problem that the workflow for the fluidx tubes is inside the group of the extracted tubes and it does not let you continue working with them without processing all the extracted tubes. 

The problem with the Transfers button is not solvable in this way. It was caused by a network connection problem and the solution should be found elsewhere.